### PR TITLE
Prevent UndeliverableExceptions when onError is called on already disposed Disposables

### DIFF
--- a/library/src/main/java/com/patloew/rxfit/BaseObservable.java
+++ b/library/src/main/java/com/patloew/rxfit/BaseObservable.java
@@ -57,7 +57,9 @@ abstract class BaseObservable<T> extends BaseRx<T> implements ObservableOnSubscr
         try {
             apiClient.connect();
         } catch (Throwable ex) {
-            subscriber.onError(ex);
+            if (!subscriber.isDisposed()) {
+                subscriber.onError(ex);
+            }
         }
 
         subscriber.setCancellable(() -> {
@@ -103,13 +105,17 @@ abstract class BaseObservable<T> extends BaseRx<T> implements ObservableOnSubscr
             try {
                 onGoogleApiClientReady(apiClient, subscriber);
             } catch (Throwable ex) {
-                subscriber.onError(ex);
+                if (!subscriber.isDisposed()) {
+                    subscriber.onError(ex);
+                }
             }
         }
 
         @Override
         public void onConnectionSuspended(int cause) {
-            subscriber.onError(new GoogleAPIConnectionSuspendedException(cause));
+            if (!subscriber.isDisposed()) {
+                subscriber.onError(new GoogleAPIConnectionSuspendedException(cause));
+            }
         }
 
         @Override
@@ -124,7 +130,10 @@ abstract class BaseObservable<T> extends BaseRx<T> implements ObservableOnSubscr
                     ctx.startActivity(intent);
                 }
             } else {
-                subscriber.onError(new GoogleAPIConnectionException("Error connecting to GoogleApiClient.", connectionResult));
+                if (!subscriber.isDisposed()) {
+                    subscriber.onError(new GoogleAPIConnectionException(
+                            "Error connecting to GoogleApiClient.", connectionResult));
+                }
             }
         }
 

--- a/library/src/main/java/com/patloew/rxfit/SingleResultCallBack.java
+++ b/library/src/main/java/com/patloew/rxfit/SingleResultCallBack.java
@@ -41,6 +41,10 @@ class SingleResultCallBack<T extends Result, R> implements ResultCallback<T> {
 
     @Override
     public void onResult(@NonNull T result) {
+        if (subscriber.isDisposed()) {
+            return;
+        }
+
         if (!result.getStatus().isSuccess()) {
             subscriber.onError(new StatusException(result.getStatus()));
         } else {

--- a/library/src/main/java/com/patloew/rxfit/StatusErrorResultCallBack.java
+++ b/library/src/main/java/com/patloew/rxfit/StatusErrorResultCallBack.java
@@ -30,7 +30,7 @@ class StatusErrorResultCallBack implements ResultCallback<Status> {
 
     @Override
     public void onResult(@NonNull Status status) {
-        if (!status.isSuccess()) {
+        if (!subscriber.isDisposed() && !status.isSuccess()) {
             subscriber.onError(new StatusException(status));
         }
     }


### PR DESCRIPTION
My app was crashing with an `UndeliverableException` when an error occurred after disposing a subscription. This change should prevent that issue.

```
debug W/System.err: io.reactivex.exceptions.UndeliverableException: com.patloew.rxfit.StatusException: Status{statusCode=The connection to Google Play services was lost, resolution=null}
debug W/System.err:     at com.patloew.rxfit.SingleResultCallBack.onResult(SingleResultCallBack.java:45)
debug W/System.err: Caused by: com.patloew.rxfit.StatusException: Status{statusCode=The connection to Google Play services was lost, resolution=null}
debug E/AndroidRuntime: FATAL EXCEPTION: main
       io.reactivex.exceptions.UndeliverableException: com.patloew.rxfit.StatusException: Status{statusCode=The connection to Google Play services was lost, resolution=null}
           at io.reactivex.plugins.RxJavaPlugins.onError(RxJavaPlugins.java:366)
           at io.reactivex.internal.operators.single.SingleCreate$Emitter.onError(SingleCreate.java:97)
           at com.patloew.rxfit.SingleResultCallBack.onResult(SingleResultCallBack.java:45)
           at com.google.android.gms.internal.zzaaf$zza.zzb(Unknown Source)
           at com.google.android.gms.internal.zzaaf$zza.handleMessage(Unknown Source)
           at android.os.Handler.dispatchMessage(Handler.java:102)
           at android.os.Looper.loop(Looper.java:154)
           at android.app.ActivityThread.main(ActivityThread.java:6121)
           at java.lang.reflect.Method.invoke(Native Method)
           at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
        Caused by: com.patloew.rxfit.StatusException: Status{statusCode=The connection to Google Play services was lost, resolution=null}
           at com.patloew.rxfit.SingleResultCallBack.onResult(SingleResultCallBack.java:45) 
           at com.google.android.gms.internal.zzaaf$zza.zzb(Unknown Source) 
           at com.google.android.gms.internal.zzaaf$zza.handleMessage(Unknown Source) 
           at android.os.Handler.dispatchMessage(Handler.java:102) 
           at android.os.Looper.loop(Looper.java:154) 
           at android.app.ActivityThread.main(ActivityThread.java:6121) 
           at java.lang.reflect.Method.invoke(Native Method) 
           at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889) 
           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779) 
```